### PR TITLE
Show win and lose states

### DIFF
--- a/src/Board.elm
+++ b/src/Board.elm
@@ -6,9 +6,13 @@ module Board exposing
     , Node(..)
     , Start
     , Status(..)
+    , anyValidMoves
+    , dotCount
+    , getDataAtNode
     , getNeighborNode
     , level1
     , levels
+    , updateBoardByNode
     )
 
 import Dict
@@ -32,6 +36,11 @@ type Node
     | K
     | L
     | M
+
+
+allNodes : List Node
+allNodes =
+    [ A, B, C, D, E, F, G, H, I, J, K, L, M ]
 
 
 type Status
@@ -72,6 +81,49 @@ type alias Board =
     , l : Cell
     , m : Cell
     }
+
+
+nodeToString : Node -> String
+nodeToString node =
+    case node of
+        A ->
+            "A"
+
+        B ->
+            "B"
+
+        C ->
+            "C"
+
+        D ->
+            "D"
+
+        E ->
+            "E"
+
+        F ->
+            "F"
+
+        G ->
+            "G"
+
+        H ->
+            "H"
+
+        I ->
+            "I"
+
+        J ->
+            "J"
+
+        K ->
+            "K"
+
+        L ->
+            "L"
+
+        M ->
+            "M"
 
 
 
@@ -241,6 +293,168 @@ getNeighborNode fromNode toNode =
 
                 _ ->
                     Nothing
+
+
+updateBoardByNode : Node -> (Cell -> Cell) -> Board -> Board
+updateBoardByNode node updateCell board =
+    case node of
+        A ->
+            { board | a = updateCell board.a }
+
+        B ->
+            { board | b = updateCell board.b }
+
+        C ->
+            { board | c = updateCell board.c }
+
+        D ->
+            { board | d = updateCell board.d }
+
+        E ->
+            { board | e = updateCell board.e }
+
+        F ->
+            { board | f = updateCell board.f }
+
+        G ->
+            { board | g = updateCell board.g }
+
+        H ->
+            { board | h = updateCell board.h }
+
+        I ->
+            { board | i = updateCell board.i }
+
+        J ->
+            { board | j = updateCell board.j }
+
+        K ->
+            { board | k = updateCell board.k }
+
+        L ->
+            { board | l = updateCell board.l }
+
+        M ->
+            { board | m = updateCell board.m }
+
+
+getDataAtNode : (Cell -> a) -> Board -> Node -> a
+getDataAtNode evaluateCell board node =
+    case node of
+        A ->
+            evaluateCell board.a
+
+        B ->
+            evaluateCell board.b
+
+        C ->
+            evaluateCell board.c
+
+        D ->
+            evaluateCell board.d
+
+        E ->
+            evaluateCell board.e
+
+        F ->
+            evaluateCell board.f
+
+        G ->
+            evaluateCell board.g
+
+        H ->
+            evaluateCell board.h
+
+        I ->
+            evaluateCell board.i
+
+        J ->
+            evaluateCell board.j
+
+        K ->
+            evaluateCell board.k
+
+        L ->
+            evaluateCell board.l
+
+        M ->
+            evaluateCell board.m
+
+
+dotCount : Board -> Int
+dotCount board =
+    List.foldl (addDots board) 0 allNodes
+
+
+addDots : Board -> Node -> Int -> Int
+addDots board node acc =
+    getDataAtNode hasDot board node + acc
+
+
+hasDot : Cell -> Int
+hasDot cell =
+    if cell.status == Dot then
+        1
+
+    else
+        0
+
+
+anyValidMoves : Board -> Bool
+anyValidMoves board =
+    List.foldr (anyValidMovesOnBoard board) False allNodes
+
+
+anyValidMovesOnBoard : Board -> Node -> Bool -> Bool
+anyValidMovesOnBoard board fromNode acc =
+    case acc of
+        True ->
+            True
+
+        False ->
+            getDataAtNode (hasValidMove board) board fromNode
+
+
+hasValidMove : Board -> Cell -> Bool
+hasValidMove board fromCell =
+    List.foldl (anyValidMovesForCell board fromCell) False allNodes
+
+
+anyValidMovesForCell : Board -> Cell -> Node -> Bool -> Bool
+anyValidMovesForCell board fromCell toNode acc =
+    case acc of
+        True ->
+            True
+
+        False ->
+            getDataAtNode (moveIsValid board toNode) board fromCell.node
+
+
+moveIsValid : Board -> Node -> Cell -> Bool
+moveIsValid board toNode fromCell =
+    let
+        fromNode =
+            fromCell.node
+
+        maybeNeighborNode =
+            getNeighborNode fromNode toNode
+    in
+    case maybeNeighborNode of
+        Nothing ->
+            False
+
+        Just neighborNode ->
+            let
+                fromStatus =
+                    getDataAtNode .status board fromNode
+
+                neighborStatus =
+                    getDataAtNode .status board neighborNode
+
+                toStatus =
+                    getDataAtNode .status board toNode
+            in
+            fromStatus == Dot && neighborStatus == Dot && toStatus == Empty
 
 
 levels : Dict.Dict Int Board

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -20,16 +20,23 @@ type alias Level =
     Int
 
 
+type GameState
+    = Won
+    | Lost
+    | InProgress
+
+
 type alias Model =
     { board : Board
     , selection : Selection
     , level : Level
+    , gameState : GameState
     }
 
 
 init : ( Model, Cmd Msg )
 init =
-    ( { board = Board.level1, selection = A, level = 1 }, Cmd.none )
+    ( { board = Board.level1, selection = A, level = 1, gameState = InProgress }, Cmd.none )
 
 
 
@@ -58,10 +65,17 @@ update msg model =
             case maybeNeighborNode of
                 Just neighborNode ->
                     if isValid model.board fromNode neighborNode toNode then
+                        let
+                            nextBoard =
+                                makeMove model.board fromNode neighborNode toNode
+
+                            nextGameState =
+                                gameState nextBoard
+                        in
                         ( { model
                             | selection = toNode
-                            , board =
-                                makeMove model.board fromNode neighborNode toNode
+                            , board = nextBoard
+                            , gameState = nextGameState
                           }
                         , Cmd.none
                         )
@@ -94,7 +108,7 @@ update msg model =
             in
             case maybeNextLevel of
                 Just level ->
-                    ( { model | level = nextLevelNumber, board = level }, Cmd.none )
+                    ( { model | level = nextLevelNumber, board = level, gameState = InProgress }, Cmd.none )
 
                 Nothing ->
                     ( model, Cmd.none )
@@ -109,13 +123,29 @@ update msg model =
             in
             case maybeNextLevel of
                 Just level ->
-                    ( { model | level = nextLevelNumber, board = level }, Cmd.none )
+                    ( { model | level = nextLevelNumber, board = level, gameState = InProgress }, Cmd.none )
 
                 Nothing ->
                     ( model, Cmd.none )
 
         NoOp ->
             ( model, Cmd.none )
+
+
+gameState : Board -> GameState
+gameState board =
+    let
+        count =
+            dotCount board
+    in
+    if count == 1 then
+        Won
+
+    else if anyValidMoves board then
+        InProgress
+
+    else
+        Lost
 
 
 isValid : Board -> Node -> Node -> Node -> Bool
@@ -127,45 +157,7 @@ isValid board fromNode neighborNode destinationNode =
 
 hasDotAt : Board -> Node -> Bool
 hasDotAt board node =
-    case node of
-        A ->
-            isDot board.a
-
-        B ->
-            isDot board.b
-
-        C ->
-            isDot board.c
-
-        D ->
-            isDot board.d
-
-        E ->
-            isDot board.e
-
-        F ->
-            isDot board.f
-
-        G ->
-            isDot board.g
-
-        H ->
-            isDot board.h
-
-        I ->
-            isDot board.i
-
-        J ->
-            isDot board.j
-
-        K ->
-            isDot board.k
-
-        L ->
-            isDot board.l
-
-        M ->
-            isDot board.m
+    getDataAtNode isDot board node
 
 
 isDot : Cell -> Bool
@@ -182,49 +174,11 @@ makeMove board fromNode neighborNode toNode =
 
 setCell : Node -> Status -> Board -> Board
 setCell node status board =
-    case node of
-        A ->
-            { board | a = setStatus board.a status }
-
-        B ->
-            { board | b = setStatus board.b status }
-
-        C ->
-            { board | c = setStatus board.c status }
-
-        D ->
-            { board | d = setStatus board.d status }
-
-        E ->
-            { board | e = setStatus board.e status }
-
-        F ->
-            { board | f = setStatus board.f status }
-
-        G ->
-            { board | g = setStatus board.g status }
-
-        H ->
-            { board | h = setStatus board.h status }
-
-        I ->
-            { board | i = setStatus board.i status }
-
-        J ->
-            { board | j = setStatus board.j status }
-
-        K ->
-            { board | k = setStatus board.k status }
-
-        L ->
-            { board | l = setStatus board.l status }
-
-        M ->
-            { board | m = setStatus board.m status }
+    updateBoardByNode node (setStatus status) board
 
 
-setStatus : Cell -> Status -> Cell
-setStatus cell status =
+setStatus : Status -> Cell -> Cell
+setStatus status cell =
     { cell | status = status }
 
 
@@ -255,9 +209,24 @@ header model =
     let
         buttonStyle =
             "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+
+        gameStateText =
+            case model.gameState of
+                Won ->
+                    "YOU WON"
+
+                Lost ->
+                    "YOU LOST"
+
+                InProgress ->
+                    ""
     in
     div [ class "flex flex-row justify-center items-center" ]
-        [ button [ onClick DecrementLevel, class buttonStyle ] [ text "<-" ]
+        [ text (String.fromInt (dotCount model.board))
+        , text gameStateText
+        , button
+            [ onClick DecrementLevel, class buttonStyle ]
+            [ text "<-" ]
         , div [ class "text-gray-800 px-4 py-4" ] [ text (String.fromInt model.level) ]
         , button [ onClick IncrementLevel, class buttonStyle ] [ text "->" ]
         , button [ onClick ResetGame, class (buttonStyle ++ " ml-8") ] [ text "Reset" ]
@@ -306,49 +275,6 @@ cellToHtml selection cell =
     div [ class "flex justify-center items-center w-24" ]
         [ div [ class style, onClick (SelectNode cell.node) ] [ text content ]
         ]
-
-
-nodeToString : Node -> String
-nodeToString node =
-    case node of
-        A ->
-            "A"
-
-        B ->
-            "B"
-
-        C ->
-            "C"
-
-        D ->
-            "D"
-
-        E ->
-            "E"
-
-        F ->
-            "F"
-
-        G ->
-            "G"
-
-        H ->
-            "H"
-
-        I ->
-            "I"
-
-        J ->
-            "J"
-
-        K ->
-            "K"
-
-        L ->
-            "L"
-
-        M ->
-            "M"
 
 
 


### PR DESCRIPTION
Why:
When a player has either lost or won the game, we would like to show a
win or lose message to the player.

This commit:
Adds the logic for determining if the game is won by seeing if there is
only one dot left.
Adds the logic for determining if the game is lost by looking to see if
there is more than one dot left and no dot has a valid move. Currently
the noValidMoves for a dot logic is a bit cumbersome and could likely be
improved if we adjusted the model to lend itself better to folds.