### PR TITLE
Add levels screen

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -1,0 +1,262 @@
+module Game exposing (Model, Msg, init, update, view)
+
+import Board exposing (..)
+import Dict
+import Html exposing (Html, a, button, div, h1, img, li, text, ul)
+import Html.Attributes exposing (class, src)
+import Html.Events exposing (onClick)
+
+
+
+---- MODEL ----
+
+
+type alias Selection =
+    Node
+
+
+type alias Level =
+    Int
+
+
+type GameState
+    = Won
+    | Lost
+    | InProgress
+
+
+type alias Model =
+    { board : Board
+    , selection : Selection
+    , level : Level
+    , gameState : GameState
+    }
+
+
+init : Model
+init =
+    { board = Board.level1
+    , selection = A
+    , level = 1
+    , gameState = InProgress
+    }
+
+
+
+---- UPDATE ----
+
+
+type Msg
+    = SelectNode Node
+    | ResetGame
+    | IncrementLevel
+    | DecrementLevel
+    | NoOp
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        SelectNode toNode ->
+            let
+                fromNode =
+                    model.selection
+
+                nextBoard =
+                    makeMove model.board fromNode toNode
+
+                nextGameState =
+                    gameState nextBoard
+            in
+            { model
+                | selection = toNode
+                , board = nextBoard
+                , gameState = nextGameState
+            }
+
+        ResetGame ->
+            let
+                maybeLevel =
+                    Dict.get model.level Board.levels
+            in
+            case maybeLevel of
+                Just level ->
+                    { model | board = level, gameState = InProgress }
+
+                Nothing ->
+                    { model | board = Board.level1, gameState = InProgress }
+
+        IncrementLevel ->
+            let
+                nextLevelNumber =
+                    model.level + 1
+
+                maybeNextLevel =
+                    Dict.get nextLevelNumber Board.levels
+            in
+            case maybeNextLevel of
+                Just level ->
+                    { model | level = nextLevelNumber, board = level, gameState = InProgress }
+
+                Nothing ->
+                    model
+
+        DecrementLevel ->
+            let
+                nextLevelNumber =
+                    model.level - 1
+
+                maybeNextLevel =
+                    Dict.get nextLevelNumber Board.levels
+            in
+            case maybeNextLevel of
+                Just level ->
+                    { model | level = nextLevelNumber, board = level, gameState = InProgress }
+
+                Nothing ->
+                    model
+
+        NoOp ->
+            model
+
+
+gameState : Board -> GameState
+gameState board =
+    let
+        count =
+            dotCount board
+    in
+    if count == 0 then
+        Won
+
+    else if anyValidMoves board then
+        InProgress
+
+    else
+        Lost
+
+
+makeMove : Board -> Node -> Node -> Board
+makeMove board fromNode toNode =
+    let
+        fromStatus =
+            getDataAtNode board fromNode
+
+        maybeNeighborNode =
+            getNeighborNode fromNode toNode
+    in
+    case maybeNeighborNode of
+        Just neighborNode ->
+            if moveIsValid board fromNode toNode then
+                case fromStatus of
+                    BlackDot ->
+                        setCell neighborNode Empty board
+                            |> setCell toNode BlackDot
+                            |> setCell fromNode Empty
+
+                    Dot ->
+                        setCell neighborNode Empty board
+                            |> setCell toNode Dot
+                            |> setCell fromNode Empty
+
+                    Empty ->
+                        board
+
+            else
+                board
+
+        Nothing ->
+            board
+
+
+setCell : Node -> Status -> Board -> Board
+setCell node status board =
+    updateBoardByNode node status board
+
+
+
+---- VIEW ----
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ gameHeader model
+        , boardToHtml model.board model.selection
+        ]
+
+
+gameHeader : Model -> Html Msg
+gameHeader model =
+    let
+        buttonStyle =
+            "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+
+        gameStateText =
+            case model.gameState of
+                Won ->
+                    "YOU WON"
+
+                Lost ->
+                    "YOU LOST"
+
+                InProgress ->
+                    ""
+    in
+    div [ class "flex flex-row justify-center items-center" ]
+        [ text (String.fromInt (dotCount model.board))
+        , text gameStateText
+        , button
+            [ onClick DecrementLevel, class buttonStyle ]
+            [ text "<-" ]
+        , div [ class "text-gray-800 px-4 py-4" ] [ text (String.fromInt model.level) ]
+        , button [ onClick IncrementLevel, class buttonStyle ] [ text "->" ]
+        , button [ onClick ResetGame, class (buttonStyle ++ " ml-8") ] [ text "Reset" ]
+        ]
+
+
+boardToHtml : Board -> Node -> Html Msg
+boardToHtml board selection =
+    let
+        cellWithBoarder =
+            cellToHtml selection
+
+        rowStyle =
+            "flex flex-row justify-center items-center"
+    in
+    div [ class "flex-column p-4 items-center justify-center border-2" ]
+        [ div [ class rowStyle ] [ cellWithBoarder A board.a, cellWithBoarder B board.b, cellWithBoarder C board.c ]
+        , div [ class rowStyle ] [ cellWithBoarder D board.d, cellWithBoarder E board.e ]
+        , div [ class rowStyle ] [ cellWithBoarder F board.f, cellWithBoarder G board.g, cellWithBoarder H board.h ]
+        , div [ class rowStyle ] [ cellWithBoarder I board.i, cellWithBoarder J board.j ]
+        , div [ class rowStyle ] [ cellWithBoarder K board.k, cellWithBoarder L board.l, cellWithBoarder M board.m ]
+        ]
+
+
+cellToHtml : Node -> Node -> Status -> Html Msg
+cellToHtml selection cellNode cellStatus =
+    let
+        baseStyle =
+            "flex items-center justify-center text-gray-700 text-center bg-gray-200 w-12 h-12 px-4 py-2 m-2"
+
+        style =
+            if cellNode == selection then
+                baseStyle ++ " border-2 border-blue-600"
+
+            else
+                baseStyle
+
+        content =
+            case cellStatus of
+                Dot ->
+                    " D "
+
+                BlackDot ->
+                    " B "
+
+                Empty ->
+                    " - "
+    in
+    div [ class "flex justify-center items-center w-24" ]
+        [ div [ class style, onClick (SelectNode cellNode) ] [ text content ]
+        ]

--- a/src/Levels.elm
+++ b/src/Levels.elm
@@ -1,0 +1,43 @@
+module Levels exposing (Model, Msg, init, update, view)
+
+import Html exposing (Html, a, button, div, h1, img, li, text, ul)
+import Html.Attributes exposing (class, src)
+
+
+
+---- MODEL ----
+
+
+type alias Model =
+    {}
+
+
+init : Model
+init =
+    {}
+
+
+
+---- UPDATE ----
+
+
+type Msg
+    = NoOp
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        NoOp ->
+            model
+
+
+
+---- VIEW ----
+
+
+view : Html Msg
+view =
+    div []
+        [ ul [] (List.map (\level -> li [] [ text ("level " ++ String.fromInt level) ]) (List.range 1 15))
+        ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,42 +1,31 @@
 module Main exposing (..)
 
-import Board exposing (..)
 import Browser
-import Dict
-import Html exposing (Html, button, div, h1, img, text, ul)
+import Game
+import Html exposing (Html, a, button, div, h1, img, li, text, ul)
 import Html.Attributes exposing (class, src)
 import Html.Events exposing (onClick)
+import Levels
 
 
 
 ---- MODEL ----
 
 
-type alias Selection =
-    Node
-
-
-type alias Level =
-    Int
-
-
-type GameState
-    = Won
-    | Lost
-    | InProgress
+type Screen
+    = Game
+    | Levels
 
 
 type alias Model =
-    { board : Board
-    , selection : Selection
-    , level : Level
-    , gameState : GameState
+    { currentScreen : Screen
+    , game : Game.Model
     }
 
 
 init : ( Model, Cmd Msg )
 init =
-    ( { board = Board.level1, selection = A, level = 1, gameState = InProgress }, Cmd.none )
+    ( { currentScreen = Game, game = Game.init }, Cmd.none )
 
 
 
@@ -44,133 +33,26 @@ init =
 
 
 type Msg
-    = SelectNode Node
-    | ResetGame
-    | IncrementLevel
-    | DecrementLevel
+    = ChangeScreen Screen
+    | GotGameMsg Game.Msg
+    | GotLevelsMsg Levels.Msg
     | NoOp
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        SelectNode toNode ->
-            let
-                fromNode =
-                    model.selection
+        ChangeScreen screen ->
+            ( { model | currentScreen = screen }, Cmd.none )
 
-                nextBoard =
-                    makeMove model.board fromNode toNode
+        GotGameMsg subMsg ->
+            ( { model | game = Game.update subMsg model.game }, Cmd.none )
 
-                nextGameState =
-                    gameState nextBoard
-            in
-            ( { model
-                | selection = toNode
-                , board = nextBoard
-                , gameState = nextGameState
-              }
-            , Cmd.none
-            )
-
-        ResetGame ->
-            let
-                maybeLevel =
-                    Dict.get model.level Board.levels
-            in
-            case maybeLevel of
-                Just level ->
-                    ( { model | board = level, gameState = InProgress }, Cmd.none )
-
-                Nothing ->
-                    ( { model | board = Board.level1, gameState = InProgress }, Cmd.none )
-
-        IncrementLevel ->
-            let
-                nextLevelNumber =
-                    model.level + 1
-
-                maybeNextLevel =
-                    Dict.get nextLevelNumber Board.levels
-            in
-            case maybeNextLevel of
-                Just level ->
-                    ( { model | level = nextLevelNumber, board = level, gameState = InProgress }, Cmd.none )
-
-                Nothing ->
-                    ( model, Cmd.none )
-
-        DecrementLevel ->
-            let
-                nextLevelNumber =
-                    model.level - 1
-
-                maybeNextLevel =
-                    Dict.get nextLevelNumber Board.levels
-            in
-            case maybeNextLevel of
-                Just level ->
-                    ( { model | level = nextLevelNumber, board = level, gameState = InProgress }, Cmd.none )
-
-                Nothing ->
-                    ( model, Cmd.none )
+        GotLevelsMsg subMsg ->
+            ( model, Cmd.none )
 
         NoOp ->
             ( model, Cmd.none )
-
-
-gameState : Board -> GameState
-gameState board =
-    let
-        count =
-            dotCount board
-    in
-    if count == 0 then
-        Won
-
-    else if anyValidMoves board then
-        InProgress
-
-    else
-        Lost
-
-
-makeMove : Board -> Node -> Node -> Board
-makeMove board fromNode toNode =
-    let
-        fromStatus =
-            getDataAtNode board fromNode
-
-        maybeNeighborNode =
-            getNeighborNode fromNode toNode
-    in
-    case maybeNeighborNode of
-        Just neighborNode ->
-            if moveIsValid board fromNode toNode then
-                case fromStatus of
-                    BlackDot ->
-                        setCell neighborNode Empty board
-                            |> setCell toNode BlackDot
-                            |> setCell fromNode Empty
-
-                    Dot ->
-                        setCell neighborNode Empty board
-                            |> setCell toNode Dot
-                            |> setCell fromNode Empty
-
-                    Empty ->
-                        board
-
-            else
-                board
-
-        Nothing ->
-            board
-
-
-setCell : Node -> Status -> Board -> Board
-setCell node status board =
-    updateBoardByNode node status board
 
 
 
@@ -180,94 +62,39 @@ setCell node status board =
 view : Model -> Html Msg
 view model =
     let
-        board =
-            model.board
+        body =
+            case model.currentScreen of
+                Game ->
+                    Html.map (\gameMsg -> GotGameMsg gameMsg) (Game.view model.game)
 
-        selection =
-            model.selection
+                Levels ->
+                    Html.map (\levelsMsg -> GotLevelsMsg levelsMsg) Levels.view
     in
     div [ class "bg-gray-100" ]
-        [ h1 [ class "text-gray-800 p-4 border-b-2 border-gray-800" ] [ text "Elm PWA Dot Game" ]
-        , div [ class "p-8" ]
-            [ header model
-            , boardToHtml board selection
+        [ div [ class "p-8" ]
+            [ header
+            , body
             ]
         ]
 
 
-header : Model -> Html Msg
-header model =
+header : Html Msg
+header =
+    div [ class "border-b-2 border-gray-800 py-8" ]
+        [ h1 [ class "text-2xl text-gray-800 " ] [ text "Elm PWA Dot Game" ]
+        , navigation
+        ]
+
+
+navigation : Html Msg
+navigation =
     let
         buttonStyle =
-            "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-
-        gameStateText =
-            case model.gameState of
-                Won ->
-                    "YOU WON"
-
-                Lost ->
-                    "YOU LOST"
-
-                InProgress ->
-                    ""
+            "bg-blue-500 text-white font-bold py-2 px-4 mr-8 rounded"
     in
-    div [ class "flex flex-row justify-center items-center" ]
-        [ text (String.fromInt (dotCount model.board))
-        , text gameStateText
-        , button
-            [ onClick DecrementLevel, class buttonStyle ]
-            [ text "<-" ]
-        , div [ class "text-gray-800 px-4 py-4" ] [ text (String.fromInt model.level) ]
-        , button [ onClick IncrementLevel, class buttonStyle ] [ text "->" ]
-        , button [ onClick ResetGame, class (buttonStyle ++ " ml-8") ] [ text "Reset" ]
-        ]
-
-
-boardToHtml : Board -> Node -> Html Msg
-boardToHtml board selection =
-    let
-        cellWithBoarder =
-            cellToHtml selection
-
-        rowStyle =
-            "flex flex-row justify-center items-center"
-    in
-    div [ class "flex-column p-4 items-center justify-center border-2" ]
-        [ div [ class rowStyle ] [ cellWithBoarder A board.a, cellWithBoarder B board.b, cellWithBoarder C board.c ]
-        , div [ class rowStyle ] [ cellWithBoarder D board.d, cellWithBoarder E board.e ]
-        , div [ class rowStyle ] [ cellWithBoarder F board.f, cellWithBoarder G board.g, cellWithBoarder H board.h ]
-        , div [ class rowStyle ] [ cellWithBoarder I board.i, cellWithBoarder J board.j ]
-        , div [ class rowStyle ] [ cellWithBoarder K board.k, cellWithBoarder L board.l, cellWithBoarder M board.m ]
-        ]
-
-
-cellToHtml : Node -> Node -> Status -> Html Msg
-cellToHtml selection cellNode cellStatus =
-    let
-        baseStyle =
-            "flex items-center justify-center text-gray-700 text-center bg-gray-200 w-12 h-12 px-4 py-2 m-2"
-
-        style =
-            if cellNode == selection then
-                baseStyle ++ " border-2 border-blue-600"
-
-            else
-                baseStyle
-
-        content =
-            case cellStatus of
-                Dot ->
-                    " D "
-
-                BlackDot ->
-                    " B "
-
-                Empty ->
-                    " - "
-    in
-    div [ class "flex justify-center items-center w-24" ]
-        [ div [ class style, onClick (SelectNode cellNode) ] [ text content ]
+    div [ class "mt-4" ]
+        [ a [ class buttonStyle, onClick (ChangeScreen Game) ] [ text "Game" ]
+        , a [ class buttonStyle, onClick (ChangeScreen Levels) ] [ text "Levels" ]
         ]
 
 


### PR DESCRIPTION
Why:
We would like for users to see a list of all the levels on a new screen.

This commit:
Pulls out the game logic to a game screen file and introduces the basic
logic for switching screens. Given this is intended to be a mobile app,
it didn't make too much sense to me to add all of the logic for
handleing url based web routing that is common in elm SPAs.

I'd much rather have a more mobile style of stack/tab/swtich navigation,
since that is what is expected on a mobile experience. The solution here
is far from that but I wanted to avoid as much complexity as possible at
this point. Given that this is a PWA and ultimately targets safari iOS
and chrome, this may be entirely the wrong direction.

Currently going to let Main.elm handle the current screen and navigation
elements and try to keep screen specific logic in screen specific files.
Again, this may be the wrong direction to go down.